### PR TITLE
Add conjugacy classes

### DIFF
--- a/gap/ConjugacyClasses.gi
+++ b/gap/ConjugacyClasses.gi
@@ -1,0 +1,195 @@
+InstallGlobalFunction( WPE_ConjugacyClasses,
+function(W)
+    local info, K, H, RK, RH, RW;
+    info := WreathProductInfo(W);
+    K := info.groups[1];
+    H := info.groups[2];
+    # TODO
+    if not IsTransitive(H) then
+        Error("TODO: intransitive top group!");
+    fi;
+    RK := List(ConjugacyClasses(K),Representative);
+    RH := List(ConjugacyClasses(H),Representative);
+    RW := List(RH, h -> WPE_ConjugacyClassesWithFixedTopClass(W, H, RK, RH, h));
+    return Concatenation(RW);
+end);
+
+InstallGlobalFunction( WPE_ConjugacyClassesWithFixedTopClass,
+function(W, H, RK, RH, hElm)
+    local r, m, h, cycles, cycleLength, l, fixPoints, omega, i, j, k, s, parts, part, blockStart, blockEnd, preTerritoryDecomposition, delta, deltaPoint, d, Ch, translations, gensD, D, shift, gensP, P, c, sigmaImage, sigma, points, point, arr, reps, iter, block, blockLength, repPoints, p, IsPointAvailable, rep, top, base, iterYades, yades, terr, gamma;
+    r := Length(RK);
+    m := NrMovedPoints(H);
+    # h is the decomposition of hElm sorted by cycle type.
+    if hElm = () then
+        h := [];
+    else
+        cycles := Cycles(hElm,MovedPoints(hElm));
+        cycleLength := List(cycles, c -> Length(c));
+        h := List(Set(cycleLength), l -> Set(List(Filtered(cycles, c -> Length(c) = l), CycleFromList)));
+    fi;
+    l := Length(h);
+    # Append the fixed points of hElm
+    fixPoints := Filtered([1 .. m], i -> not i in MovedPoints(hElm));
+    if not IsEmpty(fixPoints) then
+        h[l + 1] := fixPoints;
+        l := l + 1;
+    fi;
+    if IsNaturalSymmetricGroup(H) then
+        # omega[i] is the set of all ordered partitions of | h[i] | into at most r Yade classes.
+        omega := EmptyPlist(l);
+        for i in [1 .. l] do
+            omega[i] := [];
+            for s in [1 .. r] do
+                parts := OrderedPartitions(Length(h[i]), s);
+                for part in parts do
+                    blockStart := 1;
+                    preTerritoryDecomposition := EmptyPlist(s);
+                    for j in [1 .. s] do
+                        blockEnd := blockStart + part[j] - 1;
+                        preTerritoryDecomposition[j] := h[i]{[blockStart .. blockEnd]};
+                        blockStart := blockEnd + 1;
+                    od;
+                    Add(omega[i], preTerritoryDecomposition);
+                od;
+            od;
+        od;
+        # Compute representatives of orbits for these partitions
+        delta := Cartesian(omega);
+    else
+        # Initilise Data
+        Ch := Centraliser(H, hElm);
+        translations := EmptyPlist(l);
+        gensD := EmptyPlist(l);
+        shift := 0;
+        for i in [1 .. l] do
+            blockLength := Length(h[i]);
+            translations[i] := MappingPermListList([1 .. blockLength], [1 + shift .. blockLength + shift]);
+            gensD[i] := GeneratorsOfGroup(SymmetricGroup([1 + shift .. blockLength + shift]));
+            shift := shift + blockLength;
+        od;
+        # Image of c under projection
+        gensP := EmptyPlist(Length(GeneratorsOfGroup(Ch)));
+        for c in GeneratorsOfGroup(Ch) do
+            sigma := One(H);
+            for i in [1 .. l] do
+                blockLength := Length(h[i]);
+                sigmaImage := EmptyPlist(blockLength);
+                for j in [1 .. blockLength] do
+                    if IsPosInt(h[i,j]) then
+                        gamma := h[i, j] ^ c;
+                        sigmaImage[j] := First([1 .. blockLength], k -> gamma = h[i, k]);
+                    else
+                        gamma := MovedPoints(h[i, j])[1] ^ c;
+                        sigmaImage[j] := First([1 .. blockLength], k -> gamma in MovedPoints(h[i, k]));
+                    fi;
+                od;
+                sigma := sigma * (PermList(sigmaImage) ^ translations[i]);
+            od;
+            Add(gensP, sigma);
+        od;
+        # Right coset representatives
+        gensD := Concatenation(gensD);
+        if IsEmpty(gensD) then
+            gensD := [()];
+        fi;
+        D := Group(gensD);
+        P := Group(gensP);
+        reps := List(RightCosets(D, P), Representative);
+        # omega[i] is the set of all unordered partitions of | h[i] | into at most r Yade classes.
+        omega := List([1 .. l], i -> Union(List([1 .. r], s -> Partitions(Length(h[i]), s))));
+        iter := IteratorOfCartesianProduct(omega);
+        delta := [];
+        for part in iter do
+            # Let representatives act on the standard partitition
+            point := EmptyPlist(l);
+            for i in [1 .. l] do
+                point[i] := EmptyPlist(Length(h[i]));
+                shift := 0;
+                for blockLength in part[i] do
+                    Add(point[i], OnTuples([1 + shift .. blockLength + shift], translations[i]));
+                    shift := shift + blockLength;
+                od;
+            od;
+            points := Set(reps, rep -> List(point, block -> OnTuplesSets(block, rep)));
+            # Glue these together under the action of P
+            # O(#points * #classes)
+            repPoints := BlistList([1 .. Length(points)], [1 .. Length(points)]);
+            for i in [1 .. Length(points)] do
+                if repPoints[i] = false then
+                    continue;
+                fi;
+                for j in [i + 1 .. Length(points)] do
+                    if repPoints[j] = false then
+                        continue;
+                    fi;
+                    if RepresentativeAction(P, Concatenation(points[i]), Concatenation(points[j]), OnTuplesSets) <> fail then
+                        repPoints[j] := false;
+                    fi;
+                od;
+            od;
+            points := ListBlist(points, repPoints);
+            # Now compute all arrangements
+            for point in points do
+                p := EmptyPlist(Length(point));
+                for i in [1 .. l] do
+                    p[i] := EmptyPlist(Length(point[i]));
+                    for block in point[i] do
+                        Add(p[i], Length(block));
+                    od;
+                od;
+                for arr in Cartesian(List(p, blocks -> Arrangements(blocks, Length(blocks)))) do
+                    IsPointAvailable := List([1..l], i -> BlistList([1 .. Length(point[i])], [1 .. Length(point[i])]));
+                    deltaPoint := EmptyPlist(l);
+                    for i in [1 .. l] do
+                        deltaPoint[i] := EmptyPlist(Length(point[i]));
+                        for blockLength in arr[i] do
+                            j := First([1 .. Length(point[i])], j -> IsPointAvailable[i, j] and Length(point[i, j]) = blockLength);
+                            IsPointAvailable[i, j] := false;
+                            Add(deltaPoint[i], h[i]{OnTuples(point[i, j], translations[i] ^ -1)});
+                        od;
+                    od;
+                    Add(delta, deltaPoint);
+                od;
+            od;
+        od;
+    fi;
+    # Transform these partitions into all possible territory decompositions,
+    # i.e. choose explicit Yade classes for each partition.
+    rep := [];
+    top := hElm ^ Embedding(W, m + 1);
+    for d in delta do
+        iterYades := List(d, di -> IteratorOfCombinations(RK, Size(di)));
+        base := EmptyPlist(Length(d));
+        i := 1;
+        while i > 0 do
+            if IsDoneIterator(iterYades[i]) then
+                iterYades[i] := IteratorOfCombinations(RK, Size(d[i]));
+                Unbind(base[i]);
+                i := i - 1;
+                continue;
+            fi;
+            yades := NextIterator(iterYades[i]);
+            if i = 1 then
+                base[i] := One(W);
+            else
+                base[i] := base[i - 1];
+            fi;
+            for j in [1 .. Length(yades)] do
+                for terr in d[i,j] do
+                    if IsPosInt(terr) then
+                        gamma := terr;
+                    else
+                        gamma := SmallestMovedPoint(terr);
+                    fi;
+                    base[i] := base[i] * yades[j] ^ Embedding(W, gamma);
+                od;
+            od;
+            if i = Length(d) then
+                Add(rep, ConjugacyClass(W, base[i] * top));
+            else
+                i := i + 1;
+            fi;
+        od;
+    od;
+    return rep;
+end);

--- a/gap/WreathProductElements.gd
+++ b/gap/WreathProductElements.gd
@@ -259,3 +259,10 @@ DeclareGlobalFunction( "WPE_RepresentativeAction_PartitionBlockTopByYadeClass" )
 DeclareGlobalFunction( "WPE_RepresentativeAction_BlockMapping" );
 DeclareGlobalFunction( "WPE_RepresentativeAction_Top" );
 DeclareGlobalFunction( "WPE_RepresentativeAction_Base" );
+
+#############################################################################
+# Conjugacy Classes:
+#############################################################################
+
+DeclareGlobalFunction( "WPE_ConjugacyClasses" );
+DeclareGlobalFunction( "WPE_ConjugacyClassesWithFixedTopClass" );

--- a/read.g
+++ b/read.g
@@ -10,6 +10,9 @@ ReadPackage( "WreathProductElements", "gap/WreathProductElements.gi");
 ## Conjugacy Problem in Wreath Product
 ReadPackage( "WreathProductElements", "gap/ConjugacyProblem.gi");
 
+## Conjugacy Classes
+ReadPackage( "WreathProductElements", "gap/ConjugacyClasses.gi");
+
 ## Perm
 ReadPackage( "WreathProductElements", "gap/WreathProductPerm.gi");
 

--- a/tst/files/testConjugacyClasses.tst
+++ b/tst/files/testConjugacyClasses.tst
@@ -1,0 +1,25 @@
+gap> TestConjugacyClasses := function(K, H)
+>     local G,C,D;
+>     G := WreathProduct(K, H);
+>     C := WPE_ConjugacyClasses(G);
+>     D := ConjugacyClasses(G);
+>     return Size(C) = Size(D);
+> end;;
+gap> K := SymmetricGroup(4);;
+gap> H := SymmetricGroup(5);;
+gap> TestConjugacyClasses(K, H);
+true
+gap> K := SymmetricGroup(4);;
+gap> H := AlternatingGroup(5);;
+gap> TestConjugacyClasses(K, H);
+true
+gap> K := SymmetricGroup(4);;
+gap> H := DihedralGroup(IsPermGroup, 10);;
+gap> TestConjugacyClasses(K, H);
+true
+gap> 
+gap> # Currently only transitive top groups are supported.
+gap> #K := SymmetricGroup(4);;
+gap> #H := Group((1,2,3)(4,5));;
+gap> #TestConjugacyClasses(K, H);
+gap> 


### PR DESCRIPTION
General Approach:
- Compute right cosets C_Sym(Gamma)(h) / C_H(h)
- Compute all possible frames for partitions.
- Iterate over these frames.
- Let right coset representatives act on a standard partition of a frame.
- These points are a superset of the representatives of conjugacy classes with given frame.
- Glue these points together into classes.
- Compute all possible arrangements of the partitions in these classes.
- Compute all possible Yade distributions in these arrangements.

Approach for natural symmetric group:
- Compute all ordered partitions.
- Compute all possible Yade distributions for those partitions.